### PR TITLE
Multiple OS support (Linux/Mac OS)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -87,7 +87,7 @@ setup_asdf_source_registry() {
 # install_script <path> <lines...>
 install_script() {
     path=$1; shift
-    tmp=$(mktemp)
+    tmp=$(mktemp /tmp/tmp.XXXXXXXXXX)
 
     echo "#!/bin/sh" > "$tmp"
     for line; do

--- a/install.sh
+++ b/install.sh
@@ -122,9 +122,16 @@ install_abcl() {
     cim use abcl-system --default
 }
 
-SBCL_TARBALL_URL1="http://prdownloads.sourceforge.net/sbcl/sbcl-1.2.6-x86-64-linux-binary.tar.bz2"
-SBCL_TARBALL_URL2="http://common-lisp.net/~loliveira/tarballs/ci/sbcl-1.2.6-x86-64-linux-binary.tar.bz2"
-SBCL_TARBALL_URL3="http://kerno.org/~luis/ci/sbcl-1.2.6-x86-64-linux-binary.tar.bz2"
+case "$TRAVIS_OS_NAME" in
+    osx)
+        SBCL_TARBALL_URL1="http://prdownloads.sourceforge.net/sbcl/sbcl-1.1.8-x86-64-darwin-binary.tar.bz2"
+        ;;
+    linux|*)
+        SBCL_TARBALL_URL1="http://prdownloads.sourceforge.net/sbcl/sbcl-1.2.6-x86-64-linux-binary.tar.bz2"
+        SBCL_TARBALL_URL2="http://common-lisp.net/~loliveira/tarballs/ci/sbcl-1.2.6-x86-64-linux-binary.tar.bz2"
+        SBCL_TARBALL_URL3="http://kerno.org/~luis/ci/sbcl-1.2.6-x86-64-linux-binary.tar.bz2"
+        ;;
+esac
 SBCL_TARBALL="sbcl.tar.bz2"
 SBCL_DIR="$HOME/sbcl"
 
@@ -137,8 +144,16 @@ install_sbcl() {
     cim use sbcl-system --default
 }
 
-SBCL32_TARBALL_URL1="http://common-lisp.net/~loliveira/tarballs/sbcl-1.2.6-x86-linux-binary.tar.bz2"
-SBCL32_TARBALL_URL2="http://kerno.org/~luis/ci/sbcl-1.2.6-x86-linux-binary.tar.bz2"
+case "$TRAVIS_OS_NAME" in
+    osx)
+        SBCL32_TARBALL_URL1="http://prdownloads.sourceforge.net/sbcl/sbcl-1.1.6-x86-darwin-binary.tar.bz2"
+        ;;
+    linux|*)
+        SBCL32_TARBALL_URL1="http://common-lisp.net/~loliveira/tarballs/sbcl-1.2.6-x86-linux-binary.tar.bz2"
+        SBCL32_TARBALL_URL2="http://kerno.org/~luis/ci/sbcl-1.2.6-x86-linux-binary.tar.bz2"
+        ;;
+esac
+
 SBCL32_TARBALL="sbcl32.tar.bz2"
 SBCL32_DIR="$HOME/sbcl32"
 
@@ -154,9 +169,16 @@ install_sbcl32() {
     cim use sbcl-system --default
 }
 
-CCL_TARBALL_URL1="ftp://ftp.clozure.com/pub/release/1.10/ccl-1.10-linuxx86.tar.gz"
-CCL_TARBALL_URL2="http://kerno.org/~luis/ci/ccl-1.10-linuxx86.tar.gz"
-CCL_TARBALL_URL3="http://common-lisp.net/~loliveira/tarballs/ci/ccl-1.10-linuxx86.tar.gz"
+case "$TRAVIS_OS_NAME" in
+    osx)
+        CCL_TARBALL_URL1="ftp://ftp.clozure.com/pub/release/1.10/ccl-1.10-darwinx86.tar.gz"
+        ;;
+    linux|*)
+        CCL_TARBALL_URL1="ftp://ftp.clozure.com/pub/release/1.10/ccl-1.10-linuxx86.tar.gz"
+        CCL_TARBALL_URL2="http://kerno.org/~luis/ci/ccl-1.10-linuxx86.tar.gz"
+        CCL_TARBALL_URL3="http://common-lisp.net/~loliveira/tarballs/ci/ccl-1.10-linuxx86.tar.gz"
+        ;;
+esac
 CCL_TARBALL="ccl.tar.gz"
 CCL_DIR="$HOME/ccl"
 CCL_SCRIPT_PREFIX="/usr/local/bin"

--- a/install.sh
+++ b/install.sh
@@ -105,7 +105,17 @@ ABCL_DIR="$HOME/abcl"
 ABCL_SCRIPT="/usr/local/bin/abcl"
 
 install_abcl() {
-    sudo apt-get install default-jre
+    case "$TRAVIS_OS_NAME" in
+        linux) sudo apt-get install default-jre ;;
+        osx)
+            brew install caskroom/cask/brew-cask
+            brew cask install java
+            ;;
+        *)
+            echo "Unrecognised Travis OS: '$TRAVIS_OS_NAME'"
+            exit 1
+            ;;
+    esac
     get "$ABCL_TARBALL" "$ABCL_TARBALL_URL1" "$ABCL_TARBALL_URL2"
     unpack -z "$ABCL_TARBALL" "$ABCL_DIR"
 
@@ -223,7 +233,14 @@ install_clisp() {
         sudo ln -s /usr/bin/clisp /usr/local/bin/clisp32
     else
         echo "Installing CLISP..."
-        sudo apt-get install clisp
+        case "$TRAVIS_OS_NAME" in
+            linux) sudo apt-get install clisp ;;
+            osx) brew install clisp ;;
+            *)
+                echo "Unrecognised Travis OS: '$TRAVIS_OS_NAME'"
+                exit 1
+                ;;
+        esac
     fi
     cim use clisp-system --default
 }
@@ -277,7 +294,14 @@ install_cim() {
 (
     cd "$HOME"
 
-    sudo apt-get update
+    case "$TRAVIS_OS_NAME" in
+        linux) sudo apt-get update ;;
+        osx) brew update ;;
+        *)
+            echo "Unrecognised Travis OS: '$TRAVIS_OS_NAME'"
+            exit 1
+            ;;
+    esac
     install_cim
     install_asdf
 

--- a/install.sh
+++ b/install.sh
@@ -106,15 +106,11 @@ ABCL_SCRIPT="/usr/local/bin/abcl"
 
 install_abcl() {
     case "$TRAVIS_OS_NAME" in
-        linux) sudo apt-get install default-jre ;;
         osx)
             brew install caskroom/cask/brew-cask
             brew cask install java
             ;;
-        *)
-            echo "Unrecognised Travis OS: '$TRAVIS_OS_NAME'"
-            exit 1
-            ;;
+        linux|*) sudo apt-get install default-jre ;;
     esac
     get "$ABCL_TARBALL" "$ABCL_TARBALL_URL1" "$ABCL_TARBALL_URL2"
     unpack -z "$ABCL_TARBALL" "$ABCL_DIR"
@@ -234,12 +230,8 @@ install_clisp() {
     else
         echo "Installing CLISP..."
         case "$TRAVIS_OS_NAME" in
-            linux) sudo apt-get install clisp ;;
             osx) brew install clisp ;;
-            *)
-                echo "Unrecognised Travis OS: '$TRAVIS_OS_NAME'"
-                exit 1
-                ;;
+            linux|*) sudo apt-get install clisp ;;
         esac
     fi
     cim use clisp-system --default
@@ -295,12 +287,8 @@ install_cim() {
     cd "$HOME"
 
     case "$TRAVIS_OS_NAME" in
-        linux) sudo apt-get update ;;
         osx) brew update ;;
-        *)
-            echo "Unrecognised Travis OS: '$TRAVIS_OS_NAME'"
-            exit 1
-            ;;
+        linux|*) sudo apt-get update ;;
     esac
     install_cim
     install_asdf


### PR DESCRIPTION
Travis CI is providing a feature for testing on multiple operating systems if we ask to enable it.

http://docs.travis-ci.com/user/multi-os/

### How to try

1. Ask Travis CI's support team to enable the feature for your repository.
2. Add `os` option to your `.travis.yml`.
3. Run tests on Travis CI.

```yaml
# Example of .travis.yml
os:
  - linux
  - osx
```

### Limitations

This pull request is modifying `install.sh` for Mac OS environment with some limitations:

* `$LISP` must be one of `sbcl`, `sbcl32`, `ccl`, `abcl`, `clisp` (`ccl32`,`allegro`, `ecl` and `cmucl` are not supported)
* SBCL version is a little bit old (v1.1.8 for 64bit and v1.1.6 for 32bit)
* Binary version of SBCL for Mac OS doesn't have thread support

I tried the multi-OS feature for [Woo](https://github.com/fukamachi/woo/pull/11), but it was failed because the tests require thread-support though the binary SBCL doesn't have it.
Building from the source code or using Homebrew might be better for this.

But, anyway, I'm sending this pull request for getting your thoughts and discussing about the feature.