### PR TITLE
Answer yes to apt-get prompts, and fix 32-bit builds

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -29,8 +29,8 @@ unpack() {
 }
 
 install_i386_arch() {
-    # Travis-CI's dpkg doesn't seem to know about --add-architecture.
-    #sudo dpkg --add-architecture i386
+    sudo dpkg --add-architecture i386
+    sudo apt-get update -qq
     sudo apt-get install -y libc6:i386
 }
 

--- a/install.sh
+++ b/install.sh
@@ -31,7 +31,7 @@ unpack() {
 install_i386_arch() {
     # Travis-CI's dpkg doesn't seem to know about --add-architecture.
     #sudo dpkg --add-architecture i386
-    sudo apt-get install libc6:i386
+    sudo apt-get install -y libc6:i386
 }
 
 # add_to_lisp_rc <string>
@@ -105,7 +105,7 @@ ABCL_DIR="$HOME/abcl"
 ABCL_SCRIPT="/usr/local/bin/abcl"
 
 install_abcl() {
-    sudo apt-get install default-jre
+    sudo apt-get install -y default-jre
     get "$ABCL_TARBALL" "$ABCL_TARBALL_URL1" "$ABCL_TARBALL_URL2"
     unpack -z "$ABCL_TARBALL" "$ABCL_DIR"
 
@@ -216,13 +216,13 @@ install_ecl() {
 install_clisp() {
     if [ "$LISP" = "clisp32" ]; then
         echo "Installing 32-bit CLISP..."
-        sudo apt-get remove libsigsegv2
-        sudo apt-get install libsigsegv2:i386
-        sudo apt-get install clisp:i386
+        sudo apt-get remove -y libsigsegv2
+        sudo apt-get install -y libsigsegv2:i386
+        sudo apt-get install -y clisp:i386
         sudo ln -s /usr/bin/clisp /usr/local/bin/clisp32
     else
         echo "Installing CLISP..."
-        sudo apt-get install clisp
+        sudo apt-get install -y clisp
     fi
     cim use clisp-system --default
 }

--- a/install.sh
+++ b/install.sh
@@ -216,6 +216,7 @@ install_ecl() {
 install_clisp() {
     if [ "$LISP" = "clisp32" ]; then
         echo "Installing 32-bit CLISP..."
+        install_i386_arch
         sudo apt-get remove -y libsigsegv2
         sudo apt-get install -y libsigsegv2:i386
         sudo apt-get install -y clisp:i386


### PR DESCRIPTION
Two small fixes:
It's possible for these apt-get install lines to produce an interactive prompt, which then causes the build to time out.  This was happening with me recently and caused at least abcl builds to fail.

Meanwhile, all my 32-bit builds were failing because Travis CI's current infrastructure didn't seem to like `libc6:i386`.  Initially I replaced it with `libc6-i386` instead, but clisp32 remained broken.  Finally I managed to enable multiarch properly and this seems to fix things.

I offer the caveat that I've only tested these changes on travis-ci.org, and not on travis-ci.com which is using different infrastructure I think.